### PR TITLE
Allow user to undo single step

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -150,7 +150,7 @@ Game::makeMove(GameMove direction)
 	// This allows user to undo
 	copyBoard(fBoard, fPreviousBoard);
 	fCanUndo = true;
-	
+
 	switch (direction)
 	{
 		case Left:
@@ -362,4 +362,10 @@ Game::undoMove() {
 
 	copyBoard(fPreviousBoard, fBoard);
 	fCanUndo = false;
+
+	// Notify that the board has changed
+	// TODO: Change H2048_MOVE_MADE to something more general,
+	//       like H2048_BOARD_CHANGED?
+	BMessage moved(H2048_MOVE_MADE);
+	broadcastMessage(moved);
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -274,9 +274,10 @@ Game::makeMove(GameMove direction)
 
 	fScore += scoreChange;
 
-	// Notify boards what happened
-	BMessage moved(H2048_MOVE_MADE);
-	broadcastMessage(moved);
+	// Notify that the board has changed
+	// to redraw the board for example
+	BMessage changed(H2048_BOARD_CHANGED);
+	broadcastMessage(changed);
 
 	if (gameOver())
 	{
@@ -365,9 +366,6 @@ Game::undoMove() {
 	fScore = fPreviousScore;
 	fCanUndo = false;
 
-	// Notify that the board has changed
-	// TODO: Change H2048_MOVE_MADE to something more general,
-	//       like H2048_BOARD_CHANGED?
-	BMessage moved(H2048_MOVE_MADE);
-	broadcastMessage(moved);
+	BMessage changed(H2048_BOARD_CHANGED);
+	broadcastMessage(changed);
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -277,6 +277,7 @@ Game::makeMove(GameMove direction)
 	// Notify that the board has changed
 	// to redraw the board for example
 	BMessage changed(H2048_BOARD_CHANGED);
+	changed.AddBool("canUndo", true);
 	broadcastMessage(changed);
 
 	if (gameOver())
@@ -367,5 +368,7 @@ Game::undoMove() {
 	fCanUndo = false;
 
 	BMessage changed(H2048_BOARD_CHANGED);
+	// Now user can't undo anymore
+	changed.AddBool("canUndo", false);
 	broadcastMessage(changed);
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -146,9 +146,10 @@ Game::makeMove(GameMove direction)
 	int32 *x; // Pointer to the direction that corresponds to the X axis
 	int32 *y; // Pointer to the direction that corresponds to the Y axis
 
-	// Copy current board state before modifying it
+	// Save current board state before modifying it
 	// This allows user to undo
 	copyBoard(fBoard, fPreviousBoard);
+	fPreviousScore = fScore;
 	fCanUndo = true;
 
 	switch (direction)
@@ -361,6 +362,7 @@ Game::undoMove() {
 	if (!fCanUndo) return;
 
 	copyBoard(fPreviousBoard, fBoard);
+	fScore = fPreviousScore;
 	fCanUndo = false;
 
 	// Notify that the board has changed

--- a/Game.cpp
+++ b/Game.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
 
 #include <Message.h>

--- a/Game.h
+++ b/Game.h
@@ -60,9 +60,9 @@ private:
 	// Use a one-dimensional array for the board to save some space.
 	uint32 *						fBoard;
 
-	// Saves board state at previous move
+	// Saves board state and score at previous move
 	uint32 *						fPreviousBoard;
-
+	uint32							fPreviousScore;
 	// fCanUndo is false when:
 	// * There is no previous state to undo (right after new game)
 	// * User has already undone (can only undo once)

--- a/Game.h
+++ b/Game.h
@@ -25,6 +25,7 @@ enum GameMove
 enum
 {
 	H2048_NEW_GAME		= '48NG',
+	H2048_UNDO_MOVE     = '48UM',
 	H2048_MAKE_MOVE		= '48MM'
 };
 

--- a/Game.h
+++ b/Game.h
@@ -48,6 +48,8 @@ public:
 private:
 			void		newGame();
 			void		makeMove(GameMove direction);
+			void		undoMove();
+			void		Game::copyBoard(uint32 *from, uint32 *to);
 			void		broadcastMessage(BMessage &msg);
 			uint32 *	boardAt(uint32 x, uint32 y);
 			uint32		newTile();
@@ -57,6 +59,15 @@ private:
 	std::vector<BMessenger *>		fTargets;
 	// Use a one-dimensional array for the board to save some space.
 	uint32 *						fBoard;
+
+	// Saves board state at previous move
+	uint32 *						fPreviousBoard;
+
+	// fCanUndo is false when:
+	// * There is no previous state to undo (right after new game)
+	// * User has already undone (can only undo once)
+	bool							fCanUndo;
+
 	uint32							fSizeX, fSizeY;
 	bool							fInGame;
 	uint32							fScore;

--- a/Game.h
+++ b/Game.h
@@ -25,7 +25,7 @@ enum GameMove
 enum
 {
 	H2048_NEW_GAME		= '48NG',
-	H2048_UNDO_MOVE     = '48UM',
+	H2048_UNDO_MOVE		= '48UM',
 	H2048_MAKE_MOVE		= '48MM'
 };
 
@@ -49,28 +49,28 @@ private:
 			void		newGame();
 			void		makeMove(GameMove direction);
 			void		undoMove();
-			void		Game::copyBoard(uint32 *from, uint32 *to);
+			void		copyBoard(uint32 *from, uint32 *to);
 			void		broadcastMessage(BMessage &msg);
 			uint32 *	boardAt(uint32 x, uint32 y);
 			uint32		newTile();
 			bool		gameOver();
 
 private:
-	std::vector<BMessenger *>		fTargets;
+	std::vector<BMessenger *>	fTargets;
 	// Use a one-dimensional array for the board to save some space.
-	uint32 *						fBoard;
+	uint32 *					fBoard;
 
 	// Saves board state and score at previous move
-	uint32 *						fPreviousBoard;
-	uint32							fPreviousScore;
+	uint32 *					fPreviousBoard;
+	uint32						fPreviousScore;
 	// fCanUndo is false when:
 	// * There is no previous state to undo (right after new game)
 	// * User has already undone (can only undo once)
-	bool							fCanUndo;
+	bool						fCanUndo;
 
-	uint32							fSizeX, fSizeY;
-	bool							fInGame;
-	uint32							fScore;
+	uint32						fSizeX, fSizeY;
+	bool						fInGame;
+	uint32						fScore;
 };
 
 #endif // GAME_H

--- a/GameBoard.cpp
+++ b/GameBoard.cpp
@@ -34,7 +34,10 @@ GameBoard::MessageReceived(BMessage *message)
 			gameEnded();
 			break;
 		case H2048_BOARD_CHANGED:
-			boardChanged();
+			bool canUndo;
+			message->FindBool("canUndo", &canUndo);
+
+			boardChanged(canUndo);
 			break;
 		default:
 			break;

--- a/GameBoard.cpp
+++ b/GameBoard.cpp
@@ -33,8 +33,8 @@ GameBoard::MessageReceived(BMessage *message)
 		case H2048_GAME_ENDED:
 			gameEnded();
 			break;
-		case H2048_MOVE_MADE:
-			moveMade();
+		case H2048_BOARD_CHANGED:
+			boardChanged();
 			break;
 		default:
 			break;

--- a/GameBoard.h
+++ b/GameBoard.h
@@ -16,7 +16,7 @@ enum
 {
 	H2048_GAME_STARTED		= '48GS',
 	H2048_GAME_ENDED		= '48GE',
-	H2048_MOVE_MADE			= '48MD'
+	H2048_BOARD_CHANGED		= '48BC'
 };
 
 class GameBoard : public BLooper
@@ -30,7 +30,7 @@ protected:
 	// TODO: Pass the correct parameters and make a BMessage for them.
 	virtual	void		gameStarted() = 0;
 	virtual	void		gameEnded() = 0;
-	virtual	void		moveMade() = 0;
+	virtual	void		boardChanged() = 0;
 
 protected:
 	Game *			fTarget;

--- a/GameBoard.h
+++ b/GameBoard.h
@@ -30,7 +30,7 @@ protected:
 	// TODO: Pass the correct parameters and make a BMessage for them.
 	virtual	void		gameStarted() = 0;
 	virtual	void		gameEnded() = 0;
-	virtual	void		boardChanged() = 0;
+	virtual	void		boardChanged(bool canUndo) = 0;
 
 protected:
 	Game *			fTarget;

--- a/TerminalBoard.cpp
+++ b/TerminalBoard.cpp
@@ -41,7 +41,7 @@ TerminalBoard::gameEnded()
 }
 
 void
-TerminalBoard::moveMade()
+TerminalBoard::boardChanged()
 {
 	showBoard();
 }

--- a/TerminalBoard.cpp
+++ b/TerminalBoard.cpp
@@ -66,12 +66,18 @@ control(void *data)
 	while (true)
 	{
 		int32 c = std::cin.get();
-		if (c != 'w' && c != 'a' && c != 's' && c != 'd')
+		if (c == 'w' || c == 'a' || c == 's' || c == 'd'){
+			BMessage move(H2048_MAKE_MOVE);
+			move.AddInt32("direction", c);
+			messenger.SendMessage(&move);
+		} else if (c == 'u') {
+			BMessage undo(H2048_UNDO_MOVE);
+			messenger.SendMessage(&undo);
+		} else {
 			continue;
+		}
+		
 		std::cout << std::endl;
-		BMessage move(H2048_MAKE_MOVE);
-		move.AddInt32("direction", c);
-		messenger.SendMessage(&move);
 	}
 }
 

--- a/TerminalBoard.cpp
+++ b/TerminalBoard.cpp
@@ -41,7 +41,7 @@ TerminalBoard::gameEnded()
 }
 
 void
-TerminalBoard::boardChanged()
+TerminalBoard::boardChanged(bool canUndo)
 {
 	showBoard();
 }

--- a/TerminalBoard.h
+++ b/TerminalBoard.h
@@ -17,7 +17,7 @@ public:
 protected:
 			void		gameStarted();
 			void		gameEnded();
-			void		moveMade();
+			void		boardChanged();
 
 private:
 			void		showBoard();

--- a/TerminalBoard.h
+++ b/TerminalBoard.h
@@ -17,7 +17,7 @@ public:
 protected:
 			void		gameStarted();
 			void		gameEnded();
-			void		boardChanged();
+			void		boardChanged(bool canUndo);
 
 private:
 			void		showBoard();

--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -173,7 +173,7 @@ WindowBoard::gameEnded()
 }
 
 void
-WindowBoard::moveMade()
+WindowBoard::boardChanged()
 {
 	BMessenger messenger(NULL, fWindow);
 	messenger.SendMessage(H2048_WINDOW_SHOW);

--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -111,10 +111,15 @@ GameWindow::MessageReceived(BMessage *message)
 		{
 			const char *data;
 			ssize_t length;
-			if (fMaster->fSending && message->FindData("bytes", B_STRING_TYPE,
-				(const void **)&data, &length) == B_OK && data[0] >= 28
-				&& data[0] <= 31)
+			if (fMaster->fSending
+				&& message->FindData("bytes", B_STRING_TYPE, (const void **)&data, &length) == B_OK
+				&& (data[0] == 'u' || (data[0] >= 28 && data[0] <= 31)))
 			{
+				if (data[0] == 'u') {
+					PostMessage(H2048_UNDO_MOVE);
+					break;
+				}
+
 				GameMove m;
 
 				switch (data[0])
@@ -197,7 +202,7 @@ WindowBoard::gameStarted()
 
 void
 WindowBoard::gameEnded()
-{	
+{
 	fSending = false;
 	(new BAlert("Title", "Game Ended", "OK"))->Go();
 }

--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -26,6 +26,9 @@ GameWindow::GameWindow(WindowBoard *master)
 	BButton *newGameButton = new BButton("newgame", "New Game",
 		new BMessage(H2048_NEW_GAME));
 
+	undoButton = new BButton("undomove", "Undo last move",
+		new BMessage(H2048_UNDO_MOVE));
+
 	fScore = new BStringView("score", "Score: 0");
 
 	fBoard = new BGridLayout();
@@ -34,6 +37,7 @@ GameWindow::GameWindow(WindowBoard *master)
 		.SetInsets(B_USE_WINDOW_INSETS)
 		.AddGroup(B_HORIZONTAL)
 			.Add(newGameButton)
+			.Add(undoButton)
 			.Add(fScore)
 			.End()
 		.Add(fBoard);
@@ -81,8 +85,16 @@ GameWindow::MessageReceived(BMessage *message)
 			break;
 		}
 		case H2048_WINDOW_SHOW:
+		{
 			showBoard();
 			break;
+		}
+		case H2048_UNDO_MOVE:
+		{
+			BMessenger game(NULL, fMaster->fTarget);
+			game.SendMessage(message);
+			break;
+		}
 		case B_KEY_DOWN:
 		{
 			const char *data;

--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -28,6 +28,7 @@ GameWindow::GameWindow(WindowBoard *master)
 
 	undoButton = new BButton("undomove", "Undo last move",
 		new BMessage(H2048_UNDO_MOVE));
+	undoButton->SetEnabled(false);
 
 	fScore = new BStringView("score", "Score: 0");
 
@@ -93,6 +94,15 @@ GameWindow::MessageReceived(BMessage *message)
 		}
 		case H2048_UNDO_MOVE:
 		{
+			if (!fMaster->fSending) {
+				// fMaster->fSending is false when:
+				// * The game hasn't started (unlikely, and the button is disabled anyway)
+				// * Game over
+				// In case of game over, we have to make it true, so that
+				// subsequent keypressed are acknowledged
+				fMaster->fSending = true;
+			}
+			
 			BMessenger game(NULL, fMaster->fTarget);
 			game.SendMessage(message);
 			break;
@@ -187,7 +197,7 @@ WindowBoard::gameStarted()
 
 void
 WindowBoard::gameEnded()
-{
+{	
 	fSending = false;
 	(new BAlert("Title", "Game Ended", "OK"))->Go();
 }

--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -86,7 +86,9 @@ GameWindow::MessageReceived(BMessage *message)
 		}
 		case H2048_WINDOW_SHOW:
 		{
-			showBoard();
+			bool canUndo = false;
+			message->FindBool("canUndo", &canUndo);
+			showBoard(canUndo);
 			break;
 		}
 		case H2048_UNDO_MOVE:
@@ -135,8 +137,10 @@ GameWindow::MessageReceived(BMessage *message)
 }
 
 void
-GameWindow::showBoard()
+GameWindow::showBoard(bool canUndo)
 {
+	undoButton->SetEnabled(canUndo);
+
 	Game *target = fMaster->fTarget;
 	uint32 sizeX = target->SizeX();
 	uint32 sizeY = target->SizeY();
@@ -172,8 +176,12 @@ WindowBoard::~WindowBoard()
 void
 WindowBoard::gameStarted()
 {
+	BMessage redraw(H2048_WINDOW_SHOW);
+	redraw.AddBool("canUndo", false);
+
 	BMessenger messenger(NULL, fWindow);
-	messenger.SendMessage(H2048_WINDOW_SHOW);
+	messenger.SendMessage(&redraw);
+
 	fSending = true;
 }
 
@@ -185,8 +193,11 @@ WindowBoard::gameEnded()
 }
 
 void
-WindowBoard::boardChanged()
+WindowBoard::boardChanged(bool canUndo)
 {
+	BMessage redraw(H2048_WINDOW_SHOW);
+	redraw.AddBool("canUndo", canUndo);
+
 	BMessenger messenger(NULL, fWindow);
-	messenger.SendMessage(H2048_WINDOW_SHOW);
+	messenger.SendMessage(&redraw);
 }

--- a/WindowBoard.h
+++ b/WindowBoard.h
@@ -56,7 +56,7 @@ public:
 protected:
 			void		gameStarted();
 			void		gameEnded();
-			void		moveMade();
+			void		boardChanged();
 
 private:
 	bool				fSending;

--- a/WindowBoard.h
+++ b/WindowBoard.h
@@ -36,7 +36,7 @@ public:
 			void		MessageReceived(BMessage *message);
 
 private:
-			void		showBoard();
+			void		showBoard(bool canUndo);
 
 private:
 	NumberView **		fViews;
@@ -61,7 +61,7 @@ public:
 protected:
 			void		gameStarted();
 			void		gameEnded();
-			void		boardChanged();
+			void		boardChanged(bool canUndo);
 
 private:
 	bool				fSending;

--- a/WindowBoard.h
+++ b/WindowBoard.h
@@ -11,6 +11,7 @@
 #include <Window.h>
 
 class Game;
+class BButton;
 class NumberView;
 class WindowBoard;
 class BStringView;
@@ -42,6 +43,10 @@ private:
 	WindowBoard *		fMaster;
 	BStringView *		fScore;
 	BGridLayout *		fBoard;
+
+	// we have to control the state of it
+	// (enabled / disabled)
+	BButton * 			undoButton;
 };
 
 


### PR DESCRIPTION
This pull request adds a button to allow user to undo a single step.

The button is initially disabled after a new game. After a move is made the button is enabled, and after user undoes a move, the button is disabled again. User can undo even after encountered a Game Over.

This pull request implements #9.