### PR TITLE
Top score bar stays put on window resize

### DIFF
--- a/WindowBoard.cpp
+++ b/WindowBoard.cpp
@@ -62,6 +62,7 @@ GameWindow::GameWindow(WindowBoard *master)
 			.AddGlue()
 			.Add(fScore)
 			.End()
+		.AddGlue()
 		.Add(fBoard);
 
 


### PR DESCRIPTION
Regarding issue #28 

Tiny change to add glue to the score bar, to avoid strange spacing on window resize. 
Would it make sense to have a border or a different background to make it look more like a status bar?